### PR TITLE
AddOn -> Debugger: Add new flag to use section file names only or full path

### DIFF
--- a/sdk/add_on/debugger/debugger.cpp
+++ b/sdk/add_on/debugger/debugger.cpp
@@ -14,6 +14,7 @@ CDebugger::CDebugger()
 	m_action = CONTINUE;
 	m_lastFunction = 0;
 	m_engine = 0;
+	m_useSectionFileNameOnly = true;
 }
 
 CDebugger::~CDebugger()
@@ -227,11 +228,14 @@ bool CDebugger::CheckBreakPoint(asIScriptContext *ctx)
 	const char *tmp = 0;
 	int lineNbr = ctx->GetLineNumber(0, 0, &tmp);
 
-	// Consider just filename, not the full path
 	string file = tmp ? tmp : "";
-	size_t r = file.find_last_of("\\/");
-	if( r != string::npos )
-		file = file.substr(r+1);
+	if( m_useSectionFileNameOnly )
+	{
+		// Consider just filename, not the full path
+		size_t r = file.find_last_of("\\/");
+		if( r != string::npos )
+			file = file.substr(r+1);
+	}
 
 	// Did we move into a new function?
 	asIScriptFunction *func = ctx->GetFunction();
@@ -801,18 +805,19 @@ void CDebugger::AddFuncBreakPoint(const string &func)
 
 void CDebugger::AddFileBreakPoint(const string &file, int lineNbr)
 {
-	// Store just file name, not entire path
-	size_t r = file.find_last_of("\\/");
-	string actual;
-	if( r != string::npos )
-		actual = file.substr(r+1);
-	else
-		actual = file;
-
-	// Trim the file name
-	size_t b = actual.find_first_not_of(" \t");
-	size_t e = actual.find_last_not_of(" \t");
-	actual = actual.substr(b, e != string::npos ? e-b+1 : string::npos);
+	string actual = file;
+	if( m_useSectionFileNameOnly )
+	{
+		// Store just file name, not entire path
+		size_t r = file.find_last_of("\\/");
+		if( r != string::npos )
+			actual = file.substr(r+1);
+		
+		// Trim the file name
+		size_t b = actual.find_first_not_of(" \t");
+		size_t e = actual.find_last_not_of(" \t");
+		actual = actual.substr(b, e != string::npos ? e-b+1 : string::npos);
+	}
 
 	stringstream s;
 	s << "Setting break point in file '" << actual << "' at line " << lineNbr << endl;
@@ -858,6 +863,16 @@ void CDebugger::SetEngine(asIScriptEngine *engine)
 asIScriptEngine *CDebugger::GetEngine()
 {
 	return m_engine;
+}
+
+bool CDebugger::GetUseSectionFileNameOnly() const
+{
+	return m_useSectionFileNameOnly;
+}
+
+void CDebugger::SetUseSectionFileNameOnly(bool useSectionFileNameOnly)
+{
+	m_useSectionFileNameOnly = useSectionFileNameOnly;
 }
 
 END_AS_NAMESPACE

--- a/sdk/add_on/debugger/debugger.h
+++ b/sdk/add_on/debugger/debugger.h
@@ -54,6 +54,11 @@ public:
 	virtual void SetEngine(asIScriptEngine *engine);
 	virtual asIScriptEngine *GetEngine();
 	
+	// Sets the flag to decide if section name should be converted to just filename (true)
+	// or should not be converted and full path should be used instead (false).
+	virtual bool GetUseSectionFileNameOnly() const;
+	virtual void SetUseSectionFileNameOnly(bool useSectionFileNameOnly);
+
 protected:
 	enum DebugAction
 	{
@@ -80,6 +85,10 @@ protected:
 
 	// Registered callbacks for converting types to strings
 	std::map<const asITypeInfo*, ToStringCallback> m_toStringCallbacks;
+
+	// True (by default): For file breakpoints only the filename will be used instead the full path
+	// False: It wont convert the full path to just filename.
+	bool m_useSectionFileNameOnly;
 };
 
 END_AS_NAMESPACE


### PR DESCRIPTION
Hello,

these days I've been using the debugger addon to create a DAP in order to comunicate the VSCode debugger with the angelscript that is using my game engine ([Comet Engine](https://github.com/OriolCS2/CometEngine)), but I found a problem:

The addon debugger transforms the section names to just a single name. When I compile a file I add the section as follow:
"Assets/Scripts/Player". CheckBreakPoint method converts my path to "Player" so it never finds any breakpoint because I have overridden AddFileBreakPoint to do other stuff and also to push_back the new breakpoint with "Assets/Scripts/Player".

I've added a flag that if it is true (by default it is) nothing changes from the current behaviour, but if you set it to false then the debbuger will not convert the section to just filenames. So now when I setup a breakpoint or when LineCallback is called the debbuger works with "Assets/Scripts/Player" instead of just "Player". 

This change fixes also the problem of having more than one file with the same name as now breakpoints can be tracked with a full path so more than one script can be named the same as another one.

I tried to follow the code style, but if something is not correct feel free to ask! Also if I'm not explaining the problem well, I could try it again.

Thanks for the amazing work on angelscript! It's incredible!