### PR TITLE
Fix restore code to add ref to function template sub types

### DIFF
--- a/sdk/angelscript/source/as_restore.cpp
+++ b/sdk/angelscript/source/as_restore.cpp
@@ -1198,7 +1198,10 @@ void asCReader::ReadFunctionSignature(asCScriptFunction *func, asCObjectType **p
 		count = ReadEncodedUInt();
 		func->templateSubTypes.SetLength(count);
 		for (asUINT n = 0; n < count; n++)
-			ReadDataType(&func->templateSubTypes[n]);
+        {
+            ReadDataType(&func->templateSubTypes[n]);
+            func->templateSubTypes[n].GetTypeInfo()->AddRefInternal();
+        }
 	}
 }
 


### PR DESCRIPTION
Without this there is a crash when shutting down the engine in as_scriptfunction.cpp on the templateSubTypes[n].GetTypeInfo()->ReleaseInternal(); line as the type had already been released.

```
	// Release template sub types
	for (asUINT n = 0; n < templateSubTypes.GetLength(); n++)
		if(templateSubTypes[n].GetTypeInfo())
			templateSubTypes[n].GetTypeInfo()->ReleaseInternal();
```