### PR TITLE
fixing extra code that breaks pre c++11 compability

### DIFF
--- a/sdk/angelscript/include/angelscript.h
+++ b/sdk/angelscript/include/angelscript.h
@@ -210,7 +210,7 @@ enum asECallConvTypes
 };
 
 // Object type flags
-enum asEObjTypeFlags : asQWORD
+enum asEObjTypeFlags
 {
 	asOBJ_REF                         = (1<<0),
 	asOBJ_VALUE                       = (1<<1),

--- a/sdk/angelscript/include/angelscript.h
+++ b/sdk/angelscript/include/angelscript.h
@@ -250,7 +250,6 @@ enum asEObjTypeFlags
 	asOBJ_APP_CLASS_ALIGN8            = (1<<19),
 	asOBJ_IMPLICIT_HANDLE             = (1<<20),
 	asOBJ_APP_CLASS_UNION             = (asQWORD(1)<<32),
-	asOBJ_MASK_VALID_FLAGS            = 0x1801FFFFFul,
 	// Internal flags
 	asOBJ_SCRIPT_OBJECT               = (1<<21),
 	asOBJ_SHARED                      = (1<<22),
@@ -263,6 +262,9 @@ enum asEObjTypeFlags
 	asOBJ_ABSTRACT                    = (1<<29),
 	asOBJ_APP_ALIGN16                 = (1<<30)
 };
+
+
+#define asOBJ_MASK_VALID_FLAGS 0x1801FFFFF // need to be define since it is too large for asQWORD on 32-bit platforms
 
 // Behaviours
 enum asEBehaviours

--- a/sdk/angelscript/source/as_builder.cpp
+++ b/sdk/angelscript/source/as_builder.cpp
@@ -911,7 +911,9 @@ void asCBuilder::RegisterNamespaceVisibility(asCScriptNode* node, asCScriptCode*
 
 void asCBuilder::AddVisibleNamespaces(asSNameSpace *ns, const asCArray<asSNameSpace*>& visited, asCArray<asSNameSpace*>& pending)
 {
-	asSMapNode<asSNameSpace*, asCArray<asSNameSpace*>>* cursor = 0;
+	asSMapNode<
+		asSNameSpace*, asCArray<asSNameSpace*>
+	>* cursor = 0;
 
 	if (namespaceVisibility.MoveTo(&cursor, ns))
 	{
@@ -2267,7 +2269,9 @@ int asCBuilder::RegisterUsingNamespace(asCScriptNode *node, asCScriptCode *file,
 	}
 
 	asSNameSpace* visibleNamespace = engine->AddNameSpace(name.AddressOf());
-	asSMapNode<asSNameSpace*, asCArray<asSNameSpace*>>* cursor = 0;
+	asSMapNode<
+		asSNameSpace*, asCArray<asSNameSpace*>
+	>* cursor = 0;
 
 	if (namespaceVisibility.MoveTo(&cursor, ns))
 	{

--- a/sdk/angelscript/source/as_builder.h
+++ b/sdk/angelscript/source/as_builder.h
@@ -203,7 +203,9 @@ protected:
 
 	asCScriptEngine *engine;
 	asCModule       *module;
-	asCMap<asSNameSpace*, asCArray<asSNameSpace*>>    namespaceVisibility;
+	asCMap<
+		asSNameSpace*, asCArray<asSNameSpace*>
+	> namespaceVisibility;
 
 #ifndef AS_NO_COMPILER
 protected:

--- a/sdk/angelscript/source/as_compiler.cpp
+++ b/sdk/angelscript/source/as_compiler.cpp
@@ -1457,7 +1457,7 @@ void asCCompiler::CompileStatementBlock(asCScriptNode *block, bool ownVariableSc
 				name += asCString(&script->code[n->tokenPos], n->tokenLength);
 			}
 
-			auto visibleNamespace = engine->FindNameSpace(name.AddressOf());
+			asSNameSpace* visibleNamespace = engine->FindNameSpace(name.AddressOf());
 
 			if (visibleNamespace == 0)
 			{

--- a/sdk/angelscript/source/as_scriptfunction.h
+++ b/sdk/angelscript/source/as_scriptfunction.h
@@ -300,7 +300,8 @@ public:
 	void ReleaseAllHandles(asIScriptEngine *engine);
 
 	// Don't allow the script function to be copied
-	asCScriptFunction(const asCScriptFunction&) = delete;
+private:
+	asCScriptFunction(const asCScriptFunction&);
 
 public:
 	//-----------------------------------

--- a/sdk/angelscript/source/as_typeinfo.h
+++ b/sdk/angelscript/source/as_typeinfo.h
@@ -190,7 +190,9 @@ protected:
 struct asSEnumValue
 {
 	asCString name;
-	asINT64   value = 0;
+	asINT64   value;
+
+	asSEnumValue() : value() {}
 };
 
 class asCEnumType : public asCTypeInfo


### PR DESCRIPTION
Since library is written without any c++11 features except 3-5 places it would be nice to have older C++ compatibility. 

I'm using it with some really old gcc and borland compilers and it is compiling fine with tiny modifications I've made.

Current PR is for main library core (without add-ons) compatibility.