### PR TITLE
as_callfunc_arm_gcc.S: repair ARM build for NDK

### DIFF
--- a/sdk/angelscript/source/as_callfunc_arm_gcc.S
+++ b/sdk/angelscript/source/as_callfunc_arm_gcc.S
@@ -53,6 +53,12 @@
 .global armFuncObjLast
 .global armFuncR0ObjLast
 
+.type armFunc, %function
+.type armFuncR0, %function
+.type armFuncR0R1, %function
+.type armFuncObjLast, %function
+.type armFuncR0ObjLast, %function
+
 /* --------------------------------------------------------------------------------------------*/
 armFunc:
     stmdb   sp!, {r4-r8, lr}
@@ -315,6 +321,7 @@ nomoreargsarmFuncR0R1:
     .arm            /* Use ARM instructions instead of Thumb.*/
 #endif
     .globl armFunc  /* Make the function globally accessible.*/
+    .type armFunc, %function
 armFunc:
     push    {r4-r8, r10, r11, lr}   /* sp must be 8-byte alignment for ABI compliance, so the pushed registers must be even */
 
@@ -387,15 +394,16 @@ nomoreargs:
     .arm            /* Use ARM instructions instead of Thumb.*/
 #endif
     .globl armFuncObjLast       /* Make the function globally accessible.*/
+    .type armFuncObjLast, %function
 armFuncObjLast:
-    push {r4-r8, r10, r11, lr}  /* We´re storing r11 just to keep the stack aligned to an 8 byte boundary */
+    push {r4-r8, r10, r11, lr}  /* WeÂ´re storing r11 just to keep the stack aligned to an 8 byte boundary */
 
     mov     r6, r0  /* arg table */
     movs    r7, r1  /* arg size (also set the condition code flags so that we detect if there are no arguments) */
     mov     r4, r2  /* function address */
 
     mov     r0, r3          /* objlast. might get overwritten */
-    mov     r5, #0          /* This will hold an offset of #4 only if objlast couldn´t be placed into an "r" register */
+    mov     r5, #0          /* This will hold an offset of #4 only if objlast couldnÂ´t be placed into an "r" register */
 
     /* Load float and double args into d0-d7 and s0-s15 (r10 holds pointer to first float value) */
     add     r10, r6, #272   /* r10 (r6 + 272) points to the first value for the VFP registers */
@@ -474,6 +482,7 @@ nomoreargsarmFuncObjLast:
     .arm            /* Use ARM instructions instead of Thumb.*/
 #endif
     .globl armFuncR0ObjLast     /* Make the function globally accessible.*/
+    .type armFuncR0ObjLast, %function
 armFuncR0ObjLast:
     push    {r4-r8, r10, r11, lr}
 
@@ -485,7 +494,7 @@ armFuncR0ObjLast:
 
     mov     r0, r3      /* r0 explicitly set */
     mov     r1, r5      /* objlast.  might get overwritten */
-    mov     r5, #0      /* This will hold an offset of #4 or #8 if objlast or one arg couldn´t be placed into an "r" register */
+    mov     r5, #0      /* This will hold an offset of #4 or #8 if objlast or one arg couldnÂ´t be placed into an "r" register */
 
     /* Load float and double args into d0-d7 and s0-s15 (r10 holds pointer to first float value) */
     add     r10, r6, #272   /* r10 (r6 + 272) points to the first value for the VFP registers */
@@ -517,7 +526,7 @@ armFuncR0ObjLast:
     str     r5, [r6, #12]           /* Put objlast in r6 + 12 */
     mov     r5, #0
 
-    movge   r5, #4                  /* Set r5 with an offset of #4 if there´s one last arg that couldn´t be placed in r registers */
+    movge   r5, #4                  /* Set r5 with an offset of #4 if thereÂ´s one last arg that couldnÂ´t be placed in r registers */
     add     r5, r5, #4              /* Set r5 with an offset of + #4, so objlast can be loaded into the stack */
 
 stackargsFuncR0ObjLast:
@@ -568,6 +577,7 @@ nomoreargsarmFuncR0ObjLast:
     .arm            /* Use ARM instructions instead of Thumb.*/
 #endif
     .globl armFuncR0        /* Make the function globally accessible.*/
+    .type armFuncR0, %function
 armFuncR0:
     push {r4-r8, r10, r11, lr}
 
@@ -644,6 +654,7 @@ nomoreargsarmFuncR0:
     .arm            /* Use ARM instructions instead of Thumb.*/
 #endif
     .globl armFuncR0R1      /* Make the function globally accessible.*/
+    .type armFuncR0R1, %function
 armFuncR0R1:
     push {r4-r8, r10, r11, lr}
 


### PR DESCRIPTION
Hello. I have noticed that I am unable to build Android ARM.

The Android ARM build is failing because the external assembly functions (armFunc, armFuncR0, armFuncR0R1, armFuncObjLast, armFuncR0ObjLast) are not properly marked with the .type directive to indicate they are functions.

```
Change Dir: '/mnt/vcpkg-ci/b/vcpkg-ci-angelscript/arm-neon-android-dbg'

Run Build Command(s): /vcpkg/downloads/tools/ninja/1.12.1-linux/ninja -v -v -j33
[1/2] /android-ndk-r28c/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++ --target=armv7-none-linux-androideabi28 --sysroot=/android-ndk-r28c/toolchains/llvm/prebuilt/linux-x86_64/sysroot  -isystem /mnt/vcpkg-ci/installed/arm-neon-android/include -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -march=armv7-a -mthumb -Wformat -Werror=format-security -frtti -fexceptions  -fPIC   -fno-limit-debug-info    -std=gnu++11 -fPIE -MD -MT CMakeFiles/main.dir/main.cpp.o -MF CMakeFiles/main.dir/main.cpp.o.d -o CMakeFiles/main.dir/main.cpp.o -c /vcpkg/scripts/test_ports/vcpkg-ci-angelscript/project/main.cpp
[2/2] : && /android-ndk-r28c/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++ --target=armv7-none-linux-androideabi28 --sysroot=/android-ndk-r28c/toolchains/llvm/prebuilt/linux-x86_64/sysroot -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -march=armv7-a -mthumb -Wformat -Werror=format-security -frtti -fexceptions  -fPIC   -fno-limit-debug-info -Wl,--build-id=sha1 -Wl,--no-rosegment -Wl,--no-undefined-version -Wl,--fatal-warnings -Wl,--no-undefined -Qunused-arguments CMakeFiles/main.dir/main.cpp.o -o main  /mnt/vcpkg-ci/installed/arm-neon-android/debug/lib/libangelscript.a  -pthread  -latomic -lm && :
FAILED: main 
: && /android-ndk-r28c/toolchains/llvm/prebuilt/linux-x86_64/bin/clang++ --target=armv7-none-linux-androideabi28 --sysroot=/android-ndk-r28c/toolchains/llvm/prebuilt/linux-x86_64/sysroot -g -DANDROID -fdata-sections -ffunction-sections -funwind-tables -fstack-protector-strong -no-canonical-prefixes -D_FORTIFY_SOURCE=2 -march=armv7-a -mthumb -Wformat -Werror=format-security -frtti -fexceptions  -fPIC   -fno-limit-debug-info -Wl,--build-id=sha1 -Wl,--no-rosegment -Wl,--no-undefined-version -Wl,--fatal-warnings -Wl,--no-undefined -Qunused-arguments CMakeFiles/main.dir/main.cpp.o -o main  /mnt/vcpkg-ci/installed/arm-neon-android/debug/lib/libangelscript.a  -pthread  -latomic -lm && :
ld.lld: error: /mnt/vcpkg-ci/installed/arm-neon-android/debug/lib/libangelscript.a(as_callfunc_arm.cpp.o):(function CallSystemFunctionNative(asCContext*, asCScriptFunction*, void*, unsigned long*, void*, unsigned long long&, void*): .text._Z24CallSystemFunctionNativeP10asCContextP17asCScriptFunctionPvPmS3_RyS3_+0x36c): branch and link relocation: R_ARM_THM_CALL to non STT_FUNC symbol: armFuncR0 interworking not performed; consider using directive '.type armFuncR0, %function' to give symbol type STT_FUNC if interworking between ARM and Thumb is required; as_callfunc_arm.cpp:219 (/mnt/vcpkg-ci/b/angelscript/src/elscript_2-45a50c7292.clean/angelscript/source/as_callfunc_arm.cpp:219)
ld.lld: error: /mnt/vcpkg-ci/installed/arm-neon-android/debug/lib/libangelscript.a(as_callfunc_arm.cpp.o):(function CallSystemFunctionNative(asCContext*, asCScriptFunction*, void*, unsigned long*, void*, unsigned long long&, void*): .text._Z24CallSystemFunctionNativeP10asCContextP17asCScriptFunctionPvPmS3_RyS3_+0x37e): branch and link relocation: R_ARM_THM_CALL to non STT_FUNC symbol: armFunc interworking not performed; consider using directive '.type armFunc, %function' to give symbol type STT_FUNC if interworking between ARM and Thumb is required; as_callfunc_arm.cpp:223 (/mnt/vcpkg-ci/b/angelscript/src/elscript_2-45a50c7292.clean/angelscript/source/as_callfunc_arm.cpp:223)
ld.lld: error: /mnt/vcpkg-ci/installed/arm-neon-android/debug/lib/libangelscript.a(as_callfunc_arm.cpp.o):(function CallSystemFunctionNative(asCContext*, asCScriptFunction*, void*, unsigned long*, void*, unsigned long long&, void*): .text._Z24CallSystemFunctionNativeP10asCContextP17asCScriptFunctionPvPmS3_RyS3_+0x392): branch and link relocation: R_ARM_THM_CALL to non STT_FUNC symbol: armFuncR0 interworking not performed; consider using directive '.type armFuncR0, %function' to give symbol type STT_FUNC if interworking between ARM and Thumb is required; as_callfunc_arm.cpp:229 (/mnt/vcpkg-ci/b/angelscript/src/elscript_2-45a50c7292.clean/angelscript/source/as_callfunc_arm.cpp:229)
ld.lld: error: /mnt/vcpkg-ci/installed/arm-neon-android/debug/lib/libangelscript.a(as_callfunc_arm.cpp.o):(function CallSystemFunctionNative(asCContext*, asCScriptFunction*, void*, unsigned long*, void*, unsigned long long&, void*): .text._Z24CallSystemFunctionNativeP10asCContextP17asCScriptFunctionPvPmS3_RyS3_+0x3b0): branch and link relocation: R_ARM_THM_CALL to non STT_FUNC symbol: armFuncR0R1 interworking not performed; consider using directive '.type armFuncR0R1, %function' to give symbol type STT_FUNC if interworking between ARM and Thumb is required; as_callfunc_arm.cpp:236 (/mnt/vcpkg-ci/b/angelscript/src/elscript_2-45a50c7292.clean/angelscript/source/as_callfunc_arm.cpp:236)
ld.lld: error: /mnt/vcpkg-ci/installed/arm-neon-android/debug/lib/libangelscript.a(as_callfunc_arm.cpp.o):(function CallSystemFunctionNative(asCContext*, asCScriptFunction*, void*, unsigned long*, void*, unsigned long long&, void*): .text._Z24CallSystemFunctionNativeP10asCContextP17asCScriptFunctionPvPmS3_RyS3_+0x3ce): branch and link relocation: R_ARM_THM_CALL to non STT_FUNC symbol: armFuncR0R1 interworking not performed; consider using directive '.type armFuncR0R1, %function' to give symbol type STT_FUNC if interworking between ARM and Thumb is required; as_callfunc_arm.cpp:243 (/mnt/vcpkg-ci/b/angelscript/src/elscript_2-45a50c7292.clean/angelscript/source/as_callfunc_arm.cpp:243)
ld.lld: error: /mnt/vcpkg-ci/installed/arm-neon-android/debug/lib/libangelscript.a(as_callfunc_arm.cpp.o):(function CallSystemFunctionNative(asCContext*, asCScriptFunction*, void*, unsigned long*, void*, unsigned long long&, void*): .text._Z24CallSystemFunctionNativeP10asCContextP17asCScriptFunctionPvPmS3_RyS3_+0x402): branch and link relocation: R_ARM_THM_CALL to non STT_FUNC symbol: armFuncR0 interworking not performed; consider using directive '.type armFuncR0, %function' to give symbol type STT_FUNC if interworking between ARM and Thumb is required; as_callfunc_arm.cpp:250 (/mnt/vcpkg-ci/b/angelscript/src/elscript_2-45a50c7292.clean/angelscript/source/as_callfunc_arm.cpp:250)
ld.lld: error: /mnt/vcpkg-ci/installed/arm-neon-android/debug/lib/libangelscript.a(as_callfunc_arm.cpp.o):(function CallSystemFunctionNative(asCContext*, asCScriptFunction*, void*, unsigned long*, void*, unsigned long long&, void*): .text._Z24CallSystemFunctionNativeP10asCContextP17asCScriptFunctionPvPmS3_RyS3_+0x444): branch and link relocation: R_ARM_THM_CALL to non STT_FUNC symbol: armFuncR0R1 interworking not performed; consider using directive '.type armFuncR0R1, %function' to give symbol type STT_FUNC if interworking between ARM and Thumb is required; as_callfunc_arm.cpp:259 (/mnt/vcpkg-ci/b/angelscript/src/elscript_2-45a50c7292.clean/angelscript/source/as_callfunc_arm.cpp:259)
ld.lld: error: /mnt/vcpkg-ci/installed/arm-neon-android/debug/lib/libangelscript.a(as_callfunc_arm.cpp.o):(function CallSystemFunctionNative(asCContext*, asCScriptFunction*, void*, unsigned long*, void*, unsigned long long&, void*): .text._Z24CallSystemFunctionNativeP10asCContextP17asCScriptFunctionPvPmS3_RyS3_+0x458): branch and link relocation: R_ARM_THM_CALL to non STT_FUNC symbol: armFuncObjLast interworking not performed; consider using directive '.type armFuncObjLast, %function' to give symbol type STT_FUNC if interworking between ARM and Thumb is required; as_callfunc_arm.cpp:266 (/mnt/vcpkg-ci/b/angelscript/src/elscript_2-45a50c7292.clean/angelscript/source/as_callfunc_arm.cpp:266)
ld.lld: error: /mnt/vcpkg-ci/installed/arm-neon-android/debug/lib/libangelscript.a(as_callfunc_arm.cpp.o):(function CallSystemFunctionNative(asCContext*, asCScriptFunction*, void*, unsigned long*, void*, unsigned long long&, void*): .text._Z24CallSystemFunctionNativeP10asCContextP17asCScriptFunctionPvPmS3_RyS3_+0x476): branch and link relocation: R_ARM_THM_CALL to non STT_FUNC symbol: armFuncR0ObjLast interworking not performed; consider using directive '.type armFuncR0ObjLast, %function' to give symbol type STT_FUNC if interworking between ARM and Thumb is required; as_callfunc_arm.cpp:269 (/mnt/vcpkg-ci/b/angelscript/src/elscript_2-45a50c7292.clean/angelscript/source/as_callfunc_arm.cpp:269)
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```

