### PR TITLE
Fix the crash with uninitialized storage in asCGlobalProperty

### DIFF
--- a/sdk/angelscript/source/as_globalproperty.cpp
+++ b/sdk/angelscript/source/as_globalproperty.cpp
@@ -39,6 +39,7 @@ BEGIN_AS_NAMESPACE
 
 asCGlobalProperty::asCGlobalProperty() 
 { 
+	storage         = 0;
 	memory          = &storage; 
 	memoryAllocated = false; 
 	realAddress     = 0; 


### PR DESCRIPTION
Thanks for your fantastic scripting engine. I intergrate it with my app for binary data analysis. However, I found a bug that will cause the app crash because of uninitialize a unallocated global property.

I custom the string registeration with `QString` In Qt framework reguarding it as a value type. Then I do some operation and create a module named `mod`. The following codes are simulate the user input to declare a global variable:

```c++
mod->CompileGlobalVar(nullptr, "string a = \"123\";", 0);
mod->CompileGlobalVar(nullptr, "string a = \"456\";", 0);  // should report error
``` 

However, It crashed. I backtrace the stack and find that the engine `CallFree` a invalid memory in `as_module.cpp:L499`. Then I do a deep research and then i find the clue.

When a `asCGlobalProperty` object is created, the engine will call `asCGlobalProperty::AllocateMemory`. But, `type.GetSizeOnStackDWords()==2` and then it will never allocate any memory for my `QString`. Then the app will crash if trying to free a unallocated memory.

The final reason is that **the storage in asCGlobalProperty is not initialized with `0`**. So here is PR to fix the issue