### PR TITLE
Use a string vie w type internally

### DIFF
--- a/sdk/angelscript/source/as_builder.cpp
+++ b/sdk/angelscript/source/as_builder.cpp
@@ -207,13 +207,13 @@ void asCBuilder::Reset()
 }
 
 #ifndef AS_NO_COMPILER
-int asCBuilder::AddCode(const char *name, const char *code, int codeLength, int lineOffset, int sectionIdx, bool makeCopy)
+int asCBuilder::AddCode(const char *name, asStringView code, int lineOffset, int sectionIdx, bool makeCopy)
 {
 	asCScriptCode *script = asNEW(asCScriptCode);
 	if( script == 0 )
 		return asOUT_OF_MEMORY;
 
-	int r = script->SetCode(name, code, codeLength, makeCopy);
+	int r = script->SetCode(name, code, makeCopy);
 	if( r < 0 )
 	{
 		asDELETE(script, asCScriptCode);
@@ -227,17 +227,17 @@ int asCBuilder::AddCode(const char *name, const char *code, int codeLength, int 
 	return 0;
 }
 
-asCScriptCode *asCBuilder::FindOrAddCode(const char *name, const char *code, size_t length)
+asCScriptCode *asCBuilder::FindOrAddCode(const char *name, asStringView code)
 {
 	for (asUINT n = 0; n < scripts.GetLength(); n++)
-		if( scripts[n]->name == name && scripts[n]->codeLength == length && memcmp(scripts[n]->code, code, length) == 0 )
+		if( scripts[n]->name == name && asStringView(scripts[n]->code,scripts[n]->codeLength) == code)
 			return scripts[n];
 
 	asCScriptCode *script = asNEW(asCScriptCode);
 	if (script == 0)
 		return 0;
 
-	int r = script->SetCode(name, code, length, true);
+	int r = script->SetCode(name, code, true);
 	if (r < 0)
 	{
 		asDELETE(script, asCScriptCode);

--- a/sdk/angelscript/source/as_builder.h
+++ b/sdk/angelscript/source/as_builder.h
@@ -153,8 +153,8 @@ public:
 	int ValidateVirtualProperty(asCScriptFunction *func);
 
 #ifndef AS_NO_COMPILER
-	int AddCode(const char *name, const char *code, int codeLength, int lineOffset, int sectionIdx, bool makeCopy);
-	asCScriptCode *FindOrAddCode(const char *name, const char *code, size_t length);
+	int AddCode(const char *name, asStringView code, int lineOffset, int sectionIdx, bool makeCopy);
+	asCScriptCode *FindOrAddCode(const char *name, asStringView code);
 	int Build();
 
 	int CompileFunction(const char *sectionName, const char *code, int lineOffset, asDWORD compileFlags, asCScriptFunction **outFunc);

--- a/sdk/angelscript/source/as_compiler.cpp
+++ b/sdk/angelscript/source/as_compiler.cpp
@@ -2618,7 +2618,7 @@ int asCCompiler::CompileDefaultAndNamedArgs(asCScriptNode *node, asCArray<asCExp
 
 		// Parse the default arg string
 		asCParser parser(builder);
-		asCScriptCode *code = builder->FindOrAddCode("default arg", func->defaultArgs[n]->AddressOf(), func->defaultArgs[n]->GetLength());
+		asCScriptCode *code = builder->FindOrAddCode("default arg", asStringView(*func->defaultArgs[n]));
 		int r = parser.ParseExpression(code);
 		if( r < 0 )
 		{
@@ -2704,7 +2704,7 @@ int asCCompiler::CompileDefaultAndNamedArgs(asCScriptNode *node, asCArray<asCExp
 	return anyErrors ? -1 : 0;
 }
 
-asUINT asCCompiler::MatchFunctions(asCArray<int> &funcs, asCArray<asCExprContext*> &args, asCScriptNode *node, const char *name, asCArray<asSNamedArgument> *namedArgs, asCObjectType *objectType, bool isConstMethod, bool silent, bool allowObjectConstruct, const asCString &scope)
+asUINT asCCompiler::MatchFunctions(asCArray<int> &funcs, asCArray<asCExprContext*> &args, asCScriptNode *node, asStringView name, asCArray<asSNamedArgument> *namedArgs, asCObjectType *objectType, bool isConstMethod, bool silent, bool allowObjectConstruct, const asCString &scope)
 {
 	asCArray<int> origFuncs = funcs; // Keep the original list for error message
 	asUINT cost = 0;
@@ -8485,7 +8485,7 @@ asUINT asCCompiler::ImplicitConvObjectValue(asCExprContext *ctx, const asCDataTy
 				args.PushLast(ctx);
 
 				// Don't allow making copy of argument here, else the compiler can enter an infinite recursive loop
-				cost = asCC_TO_OBJECT_CONV + MatchFunctions(funcs, args, node, 0, 0, 0, false, true, false);
+				cost = asCC_TO_OBJECT_CONV + MatchFunctions(funcs, args, node, asStringView(), 0, 0, false, true, false);
 
 				// Did we find a matching constructor?
 				if (funcs.GetLength() == 1)
@@ -8590,7 +8590,7 @@ asUINT asCCompiler::ImplicitConvObjectToObject(asCExprContext *ctx, const asCDat
 		asCArray<asCExprContext *> args;
 		args.PushLast(ctx);
 
-		cost = asCC_TO_OBJECT_CONV + MatchFunctions(funcs, args, node, 0, 0, 0, false, true, false);
+		cost = asCC_TO_OBJECT_CONV + MatchFunctions(funcs, args, node, asStringView(), 0, 0, false, true, false);
 
 		// Did we find a matching constructor?
 		if( funcs.GetLength() == 1 )
@@ -9125,7 +9125,7 @@ asUINT asCCompiler::ImplicitConvPrimitiveToObject(asCExprContext *ctx, const asC
 	arg.exprNode = ctx->exprNode; // Use the same node for compiler messages
 	asCArray<asCExprContext*> args;
 	args.PushLast(&arg);
-	asUINT cost = asCC_TO_OBJECT_CONV + MatchFunctions(funcs, args, 0, 0, 0, objType, false, true, false);
+        asUINT cost = asCC_TO_OBJECT_CONV + MatchFunctions(funcs, args, 0, asStringView(), 0, objType,false, true, false);
 	if( funcs.GetLength() != 1 )
 		return asCC_NO_CONV;
 
@@ -15551,7 +15551,7 @@ bool asCCompiler::CompileOverloadedDualOperator(asCScriptNode *node, asCExprCont
 // Returns negative on compile error
 //         zero on no matching operator
 //         one on matching operator
-int asCCompiler::CompileOverloadedDualOperator2(asCScriptNode *node, const char *methodName, asCExprContext *lctx, asCExprContext *rctx, bool leftToRight, asCExprContext *ctx, bool specificReturn, const asCDataType &returnType)
+int asCCompiler::CompileOverloadedDualOperator2(asCScriptNode *node, asStringView methodName, asCExprContext *lctx, asCExprContext *rctx, bool leftToRight, asCExprContext *ctx, bool specificReturn, const asCDataType &returnType)
 {
 	// Find the matching method
 	if( lctx->type.dataType.IsObject() &&

--- a/sdk/angelscript/source/as_compiler.h
+++ b/sdk/angelscript/source/as_compiler.h
@@ -312,7 +312,7 @@ protected:
 	void CompileComparisonOperator(asCScriptNode *node, asCExprContext *l, asCExprContext *r, asCExprContext *out, eTokenType opToken = ttUnrecognizedToken);
 	void CompileBooleanOperator(asCScriptNode *node, asCExprContext *l, asCExprContext *r, asCExprContext *out, eTokenType opToken = ttUnrecognizedToken);
 	bool CompileOverloadedDualOperator(asCScriptNode *node, asCExprContext *l, asCExprContext *r, bool leftToRight, asCExprContext *out, bool isHandle = false, eTokenType opToken = ttUnrecognizedToken);
-	int  CompileOverloadedDualOperator2(asCScriptNode *node, const char *methodName, asCExprContext *l, asCExprContext *r, bool leftToRight, asCExprContext *out, bool specificReturn = false, const asCDataType &returnType = asCDataType::CreatePrimitive(ttVoid, false));
+	int  CompileOverloadedDualOperator2(asCScriptNode *node, asStringView methodName, asCExprContext *l, asCExprContext *r, bool leftToRight, asCExprContext *out, bool specificReturn = false, const asCDataType &returnType = asCDataType::CreatePrimitive(ttVoid, false));
 
 	void CompileInitList(asCExprValue *var, asCScriptNode *node, asCByteCode *bc, int isVarGlobOrMem);
 	int  CompileInitListElement(asSListPatternNode *&patternNode, asCScriptNode *&valueNode, int bufferTypeId, short bufferVar, asUINT &bufferSize, asCByteCode &byteCode, int &elementsInSubList);
@@ -345,7 +345,7 @@ protected:
 	bool IsVariableInitialized(asCExprValue *type, asCScriptNode *node);
 	void Dereference(asCExprContext *ctx, bool generateCode);
 	bool CompileRefCast(asCExprContext *ctx, const asCDataType &to, bool isExplicit, asCScriptNode *node, bool generateCode = true);
-	asUINT MatchFunctions(asCArray<int>& funcs, asCArray<asCExprContext*>& args, asCScriptNode* node, const char* name, asCArray<asSNamedArgument>* namedArgs = NULL, asCObjectType* objectType = NULL, bool isConstMethod = false, bool silent = false, bool allowObjectConstruct = true, const asCString& scope = "");
+	asUINT MatchFunctions(asCArray<int>& funcs, asCArray<asCExprContext*>& args, asCScriptNode* node, asStringView name, asCArray<asSNamedArgument>* namedArgs = NULL, asCObjectType* objectType = NULL, bool isConstMethod = false, bool silent = false, bool allowObjectConstruct = true, const asCString& scope = "");
 	asUINT MatchArgument(asCArray<int> &funcs, asCArray<asSOverloadCandidate> &matches, const asCExprContext *argExpr, int paramNum, bool allowObjectConstruct = true);
 	int  MatchArgument(asCScriptFunction *desc, const asCExprContext *argExpr, int paramNum, bool allowObjectConstruct = true);
 	void PerformFunctionCall(int funcId, asCExprContext *out, bool isConstructor = false, asCArray<asCExprContext*> *args = 0, asCObjectType *objTypeForConstruct = 0, bool useVariable = false, int varOffset = 0, int funcPtrVar = 0);

--- a/sdk/angelscript/source/as_configgroup.cpp
+++ b/sdk/angelscript/source/as_configgroup.cpp
@@ -66,7 +66,7 @@ int asCConfigGroup::Release()
 	return refCount;
 }
 
-asCTypeInfo *asCConfigGroup::FindType(const char *obj)
+asCTypeInfo *asCConfigGroup::FindType(asStringView obj)
 {
 	for( asUINT n = 0; n < types.GetLength(); n++ )
 		if( types[n]->name == obj )

--- a/sdk/angelscript/source/as_configgroup.h
+++ b/sdk/angelscript/source/as_configgroup.h
@@ -57,7 +57,7 @@ public:
 	int AddRef();
 	int Release();
 
-	asCTypeInfo *FindType(const char *name);
+	asCTypeInfo *FindType(asStringView name);
 	void RefConfigGroup(asCConfigGroup *group);
 
 	bool HasLiveObjects();

--- a/sdk/angelscript/source/as_module.cpp
+++ b/sdk/angelscript/source/as_module.cpp
@@ -242,7 +242,7 @@ int asCModule::AddScriptSection(const char *in_name, const char *in_code, size_t
 			return asOUT_OF_MEMORY;
 	}
 
-	return m_builder->AddCode(in_name, in_code, (int)in_codeLength, in_lineOffset, (int)m_engine->GetScriptSectionNameIndex(in_name ? in_name : ""), m_engine->ep.copyScriptSections);
+	return m_builder->AddCode(in_name, asStringView(in_code, in_codeLength), in_lineOffset, (int)m_engine->GetScriptSectionNameIndex(in_name ? in_name : ""), m_engine->ep.copyScriptSections);
 #endif
 }
 

--- a/sdk/angelscript/source/as_parser.cpp
+++ b/sdk/angelscript/source/as_parser.cpp
@@ -1029,8 +1029,7 @@ void asCParser::GetToken(sToken *token)
 			token->length = 0;
 		}
 		else
-			token->type = engine->tok.GetToken(&script->code[sourcePos], sourceLength - sourcePos, &token->length);
-
+			token->type = engine->tok.GetToken(asStringView(&script->code[sourcePos], sourceLength - sourcePos), &token->length);
 		token->pos = sourcePos;
 
 		// Update state

--- a/sdk/angelscript/source/as_scriptcode.cpp
+++ b/sdk/angelscript/source/as_scriptcode.cpp
@@ -58,45 +58,36 @@ asCScriptCode::~asCScriptCode()
 	}
 }
 
-int asCScriptCode::SetCode(const char *in_name, const char *in_code, bool in_makeCopy)
+int asCScriptCode::SetCode(const char *in_name, asStringView in_code, bool in_makeCopy)
 {
-	return SetCode(in_name, in_code, 0, in_makeCopy);
-}
-
-int asCScriptCode::SetCode(const char *in_name, const char *in_code, size_t in_length, bool in_makeCopy)
-{
-	if( !in_code) return asINVALID_ARG;
 	this->name = in_name ? in_name : "";
 	if( !sharedCode && code ) 
 		asDELETEARRAY(code);
 
-	if( in_length == 0 )
-		in_length = strlen(in_code);
 	if( in_makeCopy )
 	{
-		codeLength = in_length;
+		codeLength = in_code.len;
 		sharedCode = false;
-		code = asNEWARRAY(char, in_length);
+		code = asNEWARRAY(char, in_code.len);
 		if( code == 0 )
 			return asOUT_OF_MEMORY;
-		memcpy(code, in_code, in_length);
+		memcpy(code, in_code.string, in_code.len);
 	}
 	else
 	{
-		codeLength = in_length;
-		code = const_cast<char*>(in_code);
+		codeLength = in_code.len;
+		code = const_cast<char*>(in_code.string);
 		sharedCode = true;
 	}
 
 	// Find the positions of each line
 	linePositions.PushLast(0);
-	for( size_t n = 0; n < in_length; n++ )
+	for( size_t n = 0; n < in_code.len; n++ )
 		if( in_code[n] == '\n' ) linePositions.PushLast(n+1);
-	linePositions.PushLast(in_length);
+	linePositions.PushLast(in_code.len);
 
 	return asSUCCESS;
 }
-
 void asCScriptCode::ConvertPosToRowCol(size_t pos, int *row, int *col)
 {
 	if( linePositions.GetLength() == 0 ) 

--- a/sdk/angelscript/source/as_scriptcode.h
+++ b/sdk/angelscript/source/as_scriptcode.h
@@ -51,8 +51,7 @@ public:
 	asCScriptCode();
 	~asCScriptCode();
 
-	int SetCode(const char *name, const char *code, bool makeCopy);
-	int SetCode(const char *name, const char *code, size_t length, bool makeCopy);
+	int SetCode(const char *name, asStringView code, bool makeCopy);
 
 	void ConvertPosToRowCol(size_t pos, int *row, int *col);
 

--- a/sdk/angelscript/source/as_scriptengine.cpp
+++ b/sdk/angelscript/source/as_scriptengine.cpp
@@ -1220,7 +1220,7 @@ int asCScriptEngine::ParseNamespace(const char* nameSpace, asCArray<asCString>& 
 
 		for (; pos < ns.GetLength(); pos += len)
 		{
-			t = tok.GetToken(ns.AddressOf() + pos, ns.GetLength() - pos, &len);
+			t = tok.GetToken(asStringView(ns.AddressOf() + pos, ns.GetLength() - pos), &len);
 			if ((expectIdentifier && t != ttIdentifier) || (!expectIdentifier && t != ttScope))
 				return asINVALID_DECLARATION;
 
@@ -1422,7 +1422,7 @@ asETokenClass asCScriptEngine::ParseToken(const char *string, size_t stringLengt
 
 	size_t len;
 	asETokenClass tc;
-	tok.GetToken(string, stringLength, &len, &tc);
+	tok.GetToken(asStringView(string, stringLength), &len, &tc);
 
 	if( tokenLength )
 		*tokenLength = (asUINT)len;
@@ -1696,7 +1696,7 @@ int asCScriptEngine::RegisterInterface(const char *name)
 
 	// Make sure the name is not a reserved keyword
 	size_t tokenLen;
-	int token = tok.GetToken(name, strlen(name), &tokenLen);
+	int token = tok.GetToken(name, &tokenLen);
 	if( token != ttIdentifier || strlen(name) != tokenLen )
 		return ConfigError(asINVALID_NAME, "RegisterInterface", name, 0);
 
@@ -1989,7 +1989,7 @@ int asCScriptEngine::RegisterObjectType(const char *name, int byteSize, asQWORD 
 		{
 			// Make sure the name is not a reserved keyword
 			size_t tokenLen;
-			int token = tok.GetToken(name, typeName.GetLength(), &tokenLen);
+			int token = tok.GetToken(asStringView(name, typeName.GetLength()), &tokenLen);
 			if( token != ttIdentifier || typeName.GetLength() != tokenLen )
 				return ConfigError(asINVALID_NAME, "RegisterObjectType", name, 0);
 
@@ -6184,7 +6184,7 @@ int asCScriptEngine::RegisterTypedef(const char *type, const char *decl)
 	asCDataType dataType;
 
 	//	Create the data type
-	token = tok.GetToken(decl, strlen(decl), &tokenLen);
+	token = tok.GetToken(decl, &tokenLen);
 	switch(token)
 	{
 	case ttBool:
@@ -6211,7 +6211,7 @@ int asCScriptEngine::RegisterTypedef(const char *type, const char *decl)
 	dataType = asCDataType::CreatePrimitive(token, false);
 
 	// Make sure the name is not a reserved keyword
-	token = tok.GetToken(type, strlen(type), &tokenLen);
+	token = tok.GetToken(type, &tokenLen);
 	if( token != ttIdentifier || strlen(type) != tokenLen )
 		return ConfigError(asINVALID_NAME, "RegisterTypedef", type, decl);
 
@@ -6269,7 +6269,7 @@ int asCScriptEngine::RegisterEnum(const char* typeName, const char* underlyingTy
 
 	// make sure the type is valid
 	size_t tokenLen;
-	eTokenType token = tok.GetToken(underlyingType, strlen(underlyingType), &tokenLen);
+	eTokenType token = tok.GetToken(underlyingType, &tokenLen);
 	
 	if (!(token >= ttUInt && token <= ttUInt64) && !(token >= ttInt && token <= ttInt64))
 		return ConfigError(asINVALID_NAME, "RegisterEnum", underlyingType, 0);
@@ -6295,7 +6295,7 @@ int asCScriptEngine::RegisterEnum(const char* typeName, const char* underlyingTy
 	}
 
 	// Make sure the name is not a reserved keyword
-	token = tok.GetToken(typeName, strlen(typeName), &tokenLen);
+	token = tok.GetToken(typeName, &tokenLen);
 	if( token != ttIdentifier || strlen(typeName) != tokenLen )
 		return ConfigError(asINVALID_NAME, "RegisterEnum", typeName, 0);
 

--- a/sdk/angelscript/source/as_scriptfunction.cpp
+++ b/sdk/angelscript/source/as_scriptfunction.cpp
@@ -307,7 +307,7 @@ int asCScriptFunction::ParseListPattern(asSListPatternNode *&target, const char 
 			asCDataType dt;
 			asCBuilder builder(engine, 0);
 			asCScriptCode code;
-			code.SetCode("", decl, 0, false);
+			code.SetCode("", decl, false);
 
 			// For list factory we get the object type from the return type, for list constructor we get it from the object type directly
 			dt = builder.CreateDataTypeFromNode(listNodes, &code, engine->defaultNamespace, false, objectType ? objectType : CastToObjectType(returnType.GetTypeInfo()));

--- a/sdk/angelscript/source/as_string.cpp
+++ b/sdk/angelscript/source/as_string.cpp
@@ -41,6 +41,16 @@
 #include "as_string.h"
 #include "as_string_util.h"
 
+asStringView::asStringView(const asCString &cstr) : string(cstr.AddressOf()), len(cstr.GetLength()) {}
+asStringView::asStringView(asCString &cstr) : string(cstr.AddressOf()), len(cstr.GetLength()) {}
+bool operator==(asStringView a, asStringView b) {
+	return asCompareStrings(a.string, a.len, b.string, b.len) == 0;
+}
+bool operator!=(asStringView a, asStringView b) {
+	return asCompareStrings(a.string, a.len, b.string, b.len) != 0;
+}
+
+
 asCString::asCString()
 {
 	length = 0;
@@ -250,18 +260,9 @@ void asCString::Concatenate(const char *str, size_t len)
 	AddressOf()[length] = 0;
 }
 
-asCString &asCString::operator +=(const char *str)
+asCString &asCString::operator +=(asStringView str)
 {
-	size_t len = strlen(str);
-	Concatenate(str, len);
-
-	return *this;
-}
-
-asCString &asCString::operator +=(const asCString &str)
-{
-	Concatenate(str.AddressOf(), str.length);
-
+	Concatenate(str.string,str.len);
 	return *this;
 }
 
@@ -341,19 +342,9 @@ asCString asCString::SubString(size_t in_start, size_t in_length) const
 	return tmp;
 }
 
-int asCString::Compare(const char *str) const
+int asCString::Compare(asStringView str) const
 {
-	return asCompareStrings(AddressOf(), length, str, strlen(str));
-}
-
-int asCString::Compare(const asCString &str) const
-{
-	return asCompareStrings(AddressOf(), length, str.AddressOf(), str.GetLength());
-}
-
-int asCString::Compare(const char *str, size_t len) const
-{
-	return asCompareStrings(AddressOf(), length, str, len);
+	return asCompareStrings(AddressOf(), length, str.string, str.len);
 }
 
 size_t asCString::RecalculateLength()

--- a/sdk/angelscript/source/as_string.h
+++ b/sdk/angelscript/source/as_string.h
@@ -37,6 +37,55 @@
 
 #include <stdio.h>
 #include <string.h>
+#include "as_config.h"
+
+class asCString;
+struct asStringView {
+	asStringView() : string(""), len(0) {}
+	asStringView(const char *string) : string(string), len(string ? strlen(string) : 0)
+	{
+	}
+	asStringView(char *string) : string(string), len(string ? strlen(string) : 0)
+	{
+	}
+	asStringView(const char *string,size_t len) : string(string), len(len)
+	{
+	}
+	asStringView(char *string,size_t len) : string(string), len(len)
+	{
+	}
+	asStringView(const asCString &cstr);
+	asStringView(asCString &cstr);
+	template <typename String>
+	asStringView(const String &string) : string(string.data()), len(string.size()) {}
+
+
+
+	const char& operator[](size_t i) const
+	{ 
+		asASSERT(i < len);
+		return string[i];
+	}
+	asStringView SubString(size_t start, size_t length = (size_t)(-1)) const
+	{
+		if (start >= len || length == 0)
+			return asStringView();
+
+		if (length == (size_t)(-1))
+			length = GetLength() - start;
+
+		return asStringView(AddressOf() + start, length);
+	}
+	size_t GetLength() const { return len;}
+	const char* AddressOf() const { return string;}
+
+	const char *string;
+	size_t len;
+};
+
+bool operator==(asStringView a, asStringView b);
+bool operator!=(asStringView a, asStringView b);
+
 
 class asCString
 {
@@ -48,7 +97,7 @@ public:
 	asCString(asCString &&);
 	asCString &operator =(asCString &&);
 #endif // c++11
-
+	explicit asCString(asStringView);
 	asCString(const asCString &);
 	asCString(const char *);
 	asCString(const char *, size_t length);
@@ -59,8 +108,7 @@ public:
 	size_t GetLength() const;
 
 	void Concatenate(const char *str, size_t length);
-	asCString &operator +=(const asCString &);
-	asCString &operator +=(const char *);
+	asCString &operator +=(asStringView string);
 	asCString &operator +=(char);
 
 	void Assign(const char *str, size_t length);
@@ -74,9 +122,7 @@ public:
 
 	size_t Format(const char *fmt, ...);
 
-	int Compare(const char *str) const;
-	int Compare(const asCString &str) const;
-	int Compare(const char *str, size_t length) const;
+	int Compare(asStringView str) const;
 
 	char *AddressOf();
 	const char *AddressOf() const;
@@ -94,20 +140,16 @@ protected:
 };
 
 // Helper functions
-
-bool operator ==(const asCString &, const asCString &);
-bool operator !=(const asCString &, const asCString &);
-
-bool operator ==(const asCString &, const char *);
-bool operator !=(const asCString &, const char *);
-
-bool operator ==(const char *, const asCString &);
-bool operator !=(const char *, const asCString &);
+bool operator==(const asCString &, const asCString &);
+bool operator!=(const asCString &, const asCString &);
 
 bool operator <(const asCString &, const asCString &);
 
-asCString operator +(const asCString &, const char *);
-asCString operator +(const char *, const asCString &);
+asCString operator+(const asCString &, asStringView);
+asCString operator+(const asCString &, const char*);
+asCString operator+(const char*, const asCString&);
+
+asCString operator +(asStringView, const asCString &);
 asCString operator +(const asCString &, const asCString &);
 
 // a wrapper for using the pointer of asCString in asCMap

--- a/sdk/angelscript/source/as_tokenizer.cpp
+++ b/sdk/angelscript/source/as_tokenizer.cpp
@@ -149,27 +149,27 @@ bool asCTokenizer::IsDigitInRadix(char ch, int radix) const
 	return false;
 }
 
-eTokenType asCTokenizer::GetToken(const char *source, size_t sourceLength, size_t *tokenLength, asETokenClass *tc) const
+eTokenType asCTokenizer::GetToken(asStringView source, size_t *tokenLength, asETokenClass *tc) const
 {
-	asASSERT(source != 0);
+	asASSERT(source.string != 0);
 	asASSERT(tokenLength != 0);
 
 	eTokenType tokenType;
 	size_t     tlen;
-	asETokenClass t = ParseToken(source, sourceLength, tlen, tokenType);
+	asETokenClass t = ParseToken(source, tlen, tokenType);
 	if( tc          ) *tc          = t;
 	if( tokenLength ) *tokenLength = tlen;
 
 	return tokenType;
 }
 
-asETokenClass asCTokenizer::ParseToken(const char *source, size_t sourceLength, size_t &tokenLength, eTokenType &tokenType) const
+asETokenClass asCTokenizer::ParseToken(asStringView source, size_t &tokenLength, eTokenType &tokenType) const
 {
-	if( IsWhiteSpace(source, sourceLength, tokenLength, tokenType) ) return asTC_WHITESPACE;
-	if( IsComment(source, sourceLength, tokenLength, tokenType)    ) return asTC_COMMENT;
-	if( IsConstant(source, sourceLength, tokenLength, tokenType)   ) return asTC_VALUE;
-	if( IsIdentifier(source, sourceLength, tokenLength, tokenType) ) return asTC_IDENTIFIER;
-	if( IsKeyWord(source, sourceLength, tokenLength, tokenType)    ) return asTC_KEYWORD;
+	if( IsWhiteSpace(source, tokenLength, tokenType) ) return asTC_WHITESPACE;
+	if( IsComment(source, tokenLength, tokenType)    ) return asTC_COMMENT;
+	if( IsConstant(source, tokenLength, tokenType)   ) return asTC_VALUE;
+	if( IsIdentifier(source, tokenLength, tokenType) ) return asTC_IDENTIFIER;
+	if( IsKeyWord(source, tokenLength, tokenType)    ) return asTC_KEYWORD;
 
 	// If none of the above this is an unrecognized token
 	// We can find the length of the token by advancing
@@ -180,10 +180,10 @@ asETokenClass asCTokenizer::ParseToken(const char *source, size_t sourceLength, 
 	return asTC_UNKNOWN;
 }
 
-bool asCTokenizer::IsWhiteSpace(const char *source, size_t sourceLength, size_t &tokenLength, eTokenType &tokenType) const
+bool asCTokenizer::IsWhiteSpace(asStringView source, size_t &tokenLength, eTokenType &tokenType) const
 {
 	// Treat UTF8 byte-order-mark (EF BB BF) as whitespace
-	if( sourceLength >= 3 && 
+	if( source.len >= 3 && 
 		asBYTE(source[0]) == 0xEFu &&
 		asBYTE(source[1]) == 0xBBu &&
 		asBYTE(source[2]) == 0xBFu )
@@ -196,7 +196,7 @@ bool asCTokenizer::IsWhiteSpace(const char *source, size_t sourceLength, size_t 
 	// Group all other white space characters into one
 	size_t n;
 	int numWsChars = (int)strlen(whiteSpace);
-	for( n = 0; n < sourceLength; n++ )
+	for( n = 0; n < source.len; n++ )
 	{
 		bool isWhiteSpace = false;
 		for( int w = 0; w < numWsChars; w++ )
@@ -220,9 +220,9 @@ bool asCTokenizer::IsWhiteSpace(const char *source, size_t sourceLength, size_t 
 	return false;
 }
 
-bool asCTokenizer::IsComment(const char *source, size_t sourceLength, size_t &tokenLength, eTokenType &tokenType) const
+bool asCTokenizer::IsComment(asStringView source, size_t &tokenLength, eTokenType &tokenType) const
 {
-	if( sourceLength < 2 )
+	if( source.len < 2 )
 		return false;
 
 	if( source[0] != '/' )
@@ -234,14 +234,14 @@ bool asCTokenizer::IsComment(const char *source, size_t sourceLength, size_t &to
 
 		// Find the length
 		size_t n;
-		for( n = 2; n < sourceLength; n++ )
+		for( n = 2; n < source.len; n++ )
 		{
 			if( source[n] == '\n' )
 				break;
 		}
 
 		tokenType   = ttOnelineComment;
-		tokenLength = n < sourceLength ? n+1 : n;
+		tokenLength = n < source.len ? n + 1 : n;
 
 		return true;
 	}
@@ -252,7 +252,7 @@ bool asCTokenizer::IsComment(const char *source, size_t sourceLength, size_t &to
 
 		// Find the length
 		size_t n;
-		for( n = 2; n < sourceLength-1; )
+		for( n = 2; n < source.len-1; )
 		{
 			if( source[n++] == '*' && source[n] == '/' )
 				break;
@@ -267,11 +267,11 @@ bool asCTokenizer::IsComment(const char *source, size_t sourceLength, size_t &to
 	return false;
 }
 
-bool asCTokenizer::IsValidSeparatorDigitInRadix(const char* source, size_t sourceLength, size_t n, int radix) const
+bool asCTokenizer::IsValidSeparatorDigitInRadix(asStringView source, size_t n, int radix) const
 {
 	if (source[n] != '\'')
 		return false;
-	if ((n + 1) >= sourceLength || n == 0)
+	if ((n + 1) >= source.len || n == 0)
 		return false;
 	else if (!IsDigitInRadix(source[n + 1], radix) || !IsDigitInRadix(source[n - 1], radix))
 		return false;
@@ -279,13 +279,13 @@ bool asCTokenizer::IsValidSeparatorDigitInRadix(const char* source, size_t sourc
 	return true;
 }
 
-bool asCTokenizer::IsConstant(const char *source, size_t sourceLength, size_t &tokenLength, eTokenType &tokenType) const
+bool asCTokenizer::IsConstant(asStringView source, size_t &tokenLength, eTokenType &tokenType) const
 {
 	// Starting with number
-	if( (source[0] >= '0' && source[0] <= '9') || (source[0] == '.' && sourceLength > 1 && source[1] >= '0' && source[1] <= '9') )
+	if( (source[0] >= '0' && source[0] <= '9') || (source[0] == '.' && source.len > 1 && source[1] >= '0' && source[1] <= '9') )
 	{
 		// Is it a based number?
-		if( source[0] == '0' && sourceLength > 1 )
+		if( source[0] == '0' && source.len > 1 )
 		{
 			// Determine the radix for the constant
 			int radix = 0;
@@ -300,8 +300,8 @@ bool asCTokenizer::IsConstant(const char *source, size_t sourceLength, size_t &t
 			if( radix )
 			{
 				size_t n;
-				for( n = 2; n < sourceLength; n++ )
-					if( !IsDigitInRadix(source[n], radix) && !IsValidSeparatorDigitInRadix(source, sourceLength, n, radix) )
+				for( n = 2; n < source.len; n++ )
+					if( !IsDigitInRadix(source[n], radix) && !IsValidSeparatorDigitInRadix(source, n, radix) )
 						break;
 
 				tokenType   = ttBitsConstant;
@@ -311,38 +311,38 @@ bool asCTokenizer::IsConstant(const char *source, size_t sourceLength, size_t &t
 		}
 
 		size_t n;
-		for( n = 0; n < sourceLength; n++ )
+		for( n = 0; n < source.len; n++ )
 		{
-			if( (source[n] < '0' || source[n] > '9') && !IsValidSeparatorDigitInRadix(source, sourceLength, n, 10) )
+			if( (source[n] < '0' || source[n] > '9') && !IsValidSeparatorDigitInRadix(source, n, 10) )
 				break;
 		}
 
-		if( n < sourceLength && (source[n] == '.' || source[n] == 'e' || source[n] == 'E') )
+		if( n < source.len && (source[n] == '.' || source[n] == 'e' || source[n] == 'E') )
 		{
 			if( source[n] == '.' )
 			{
 				n++;
-				for( ; n < sourceLength; n++ )
+				for( ; n < source.len; n++ )
 				{
-					if( (source[n] < '0' || source[n] > '9') && !IsValidSeparatorDigitInRadix(source, sourceLength, n, 10) )
+					if( (source[n] < '0' || source[n] > '9') && !IsValidSeparatorDigitInRadix(source, n, 10) )
 						break;
 				}
 			}
 
-			if( n < sourceLength && (source[n] == 'e' || source[n] == 'E') )
+			if( n < source.len && (source[n] == 'e' || source[n] == 'E') )
 			{
 				n++;
-				if( n < sourceLength && (source[n] == '-' || source[n] == '+') )
+				if( n < source.len && (source[n] == '-' || source[n] == '+') )
 					n++;
 
-				for( ; n < sourceLength; n++ )
+				for( ; n < source.len; n++ )
 				{
-					if( (source[n] < '0' || source[n] > '9') && !IsValidSeparatorDigitInRadix(source, sourceLength, n, 10) )
+					if( (source[n] < '0' || source[n] > '9') && !IsValidSeparatorDigitInRadix(source, n, 10) )
 						break;
 				}
 			}
 
-			if( n < sourceLength && (source[n] == 'f' || source[n] == 'F') )
+			if( n < source.len && (source[n] == 'f' || source[n] == 'F') )
 			{
 				tokenType   = ttFloatConstant;
 				tokenLength = n + 1;
@@ -368,13 +368,13 @@ bool asCTokenizer::IsConstant(const char *source, size_t sourceLength, size_t &t
 	if( source[0] == '"' || source[0] == '\'' )
 	{
 		// Is it a normal string constant or a heredoc string constant?
-		if( sourceLength >= 6 && source[0] == '"' && source[1] == '"' && source[2] == '"' )
+		if( source.len >= 6 && source[0] == '"' && source[1] == '"' && source[2] == '"' )
 		{
 			// Heredoc string constant (spans multiple lines, no escape sequences)
 
 			// Find the length
 			size_t n;
-			for( n = 3; n < sourceLength-2; n++ )
+			for( n = 3; n < source.len-2; n++ )
 			{
 				if (source[n] == '"' && source[n + 1] == '"' && source[n + 2] == '"')
 				{
@@ -394,7 +394,7 @@ bool asCTokenizer::IsConstant(const char *source, size_t sourceLength, size_t &t
 			char quote = source[0];
 			bool evenSlashes = true;
 			size_t n;
-			for( n = 1; n < sourceLength; n++ )
+			for( n = 1; n < source.len; n++ )
 			{
 #ifdef AS_DOUBLEBYTE_CHARSET
 				// Double-byte characters are only allowed for ASCII
@@ -427,7 +427,7 @@ bool asCTokenizer::IsConstant(const char *source, size_t sourceLength, size_t &t
 	return false;
 }
 
-bool asCTokenizer::IsIdentifier(const char *source, size_t sourceLength, size_t &tokenLength, eTokenType &tokenType) const
+bool asCTokenizer::IsIdentifier(asStringView source, size_t &tokenLength, eTokenType &tokenType) const
 {
 	// char is unsigned by default on some architectures, e.g. ppc and arm
 	// Make sure the value is always treated as signed in the below comparisons
@@ -442,7 +442,7 @@ bool asCTokenizer::IsIdentifier(const char *source, size_t sourceLength, size_t 
 		tokenType   = ttIdentifier;
 		tokenLength = 1;
 
-		for( size_t n = 1; n < sourceLength; n++ )
+		for( size_t n = 1; n < source.len; n++ )
 		{
 			c = source[n];
 			if( (c >= 'a' && c <= 'z') ||
@@ -456,7 +456,7 @@ bool asCTokenizer::IsIdentifier(const char *source, size_t sourceLength, size_t 
 		}
 
 		// Make sure the identifier isn't a reserved keyword
-		if( IsKeyWord(source, tokenLength, tokenLength, tokenType) )
+		if( IsKeyWord(source.SubString(0,tokenLength), tokenLength,tokenType) )
 			return false;
 
 		return true;
@@ -465,7 +465,7 @@ bool asCTokenizer::IsIdentifier(const char *source, size_t sourceLength, size_t 
 	return false;
 }
 
-bool asCTokenizer::IsKeyWord(const char *source, size_t sourceLength, size_t &tokenLength, eTokenType &tokenType) const
+bool asCTokenizer::IsKeyWord(asStringView source, size_t &tokenLength, eTokenType &tokenType) const
 {
 	unsigned char start = source[0];
 	const sTokenWord **ptr = keywordTable[start];
@@ -476,13 +476,13 @@ bool asCTokenizer::IsKeyWord(const char *source, size_t sourceLength, size_t &to
 	for( ; *ptr; ++ptr )
 	{
 		size_t wlen = (*ptr)->wordLength;
-		if( sourceLength >= wlen && strncmp(source, (*ptr)->word, wlen) == 0 )
+		if( source.len >= wlen && source == asStringView((*ptr)->word, wlen))
 		{
 			// Tokens that end with a character that can be part of an 
 			// identifier require an extra verification to guarantee that 
 			// we don't split an identifier token, e.g. the "!is" token 
 			// and the tokens "!" and "isTrue" in the "!isTrue" expression.
-			if( wlen < sourceLength &&
+			if( wlen < source.len &&
 				((source[wlen-1] >= 'a' && source[wlen-1] <= 'z') ||
 				 (source[wlen-1] >= 'A' && source[wlen-1] <= 'Z') ||
 				 (source[wlen-1] >= '0' && source[wlen-1] <= '9')) &&

--- a/sdk/angelscript/source/as_tokenizer.h
+++ b/sdk/angelscript/source/as_tokenizer.h
@@ -50,9 +50,9 @@ BEGIN_AS_NAMESPACE
 class asCTokenizer
 {
 public:
-	eTokenType GetToken(const char *source, size_t sourceLength, size_t *tokenLength, asETokenClass *tc = 0) const;
+	eTokenType GetToken(asStringView source, size_t *tokenLength, asETokenClass *tc = 0) const;
 	
-	static const char *GetDefinition(int tokenType);
+	static const char* GetDefinition(int tokenType);
 
 protected:
 	friend class asCScriptEngine;
@@ -60,14 +60,14 @@ protected:
 	asCTokenizer();
 	~asCTokenizer();
 
-	asETokenClass ParseToken(const char *source, size_t sourceLength, size_t &tokenLength, eTokenType &tokenType) const;
-	bool IsWhiteSpace(const char *source, size_t sourceLength, size_t &tokenLength, eTokenType &tokenType) const;
-	bool IsComment(const char *source, size_t sourceLength, size_t &tokenLength, eTokenType &tokenType) const;
-	bool IsConstant(const char *source, size_t sourceLength, size_t &tokenLength, eTokenType &tokenType) const;
-	bool IsKeyWord(const char *source, size_t sourceLength, size_t &tokenLength, eTokenType &tokenType) const;
-	bool IsIdentifier(const char *source, size_t sourceLength, size_t &tokenLength, eTokenType &tokenType) const;
+	asETokenClass ParseToken(asStringView source, size_t &tokenLength, eTokenType &tokenType) const;
+    bool IsWhiteSpace(asStringView source, size_t &tokenLength,eTokenType &tokenType) const;
+	bool IsComment(asStringView source, size_t &tokenLength, eTokenType &tokenType) const;
+	bool IsConstant(asStringView source, size_t &tokenLength, eTokenType &tokenType) const;
+	bool IsKeyWord(asStringView source, size_t &tokenLength, eTokenType &tokenType) const;
+	bool IsIdentifier(asStringView source, size_t &tokenLength, eTokenType &tokenType) const;
 	bool IsDigitInRadix(char ch, int radix) const;
-	bool IsValidSeparatorDigitInRadix(const char* source, size_t sourceLength, size_t n, int radix) const;
+    bool IsValidSeparatorDigitInRadix(asStringView source, size_t n, int radix) const;
 
 	void InitJumpTable();
 	void FreeJumpTable();


### PR DESCRIPTION
Hi andreas, I am a big fan of AngelScript although I only just used it for 1 day, so I thought to contribute.

This PR makes use of a std::string_view like type to manage `const char*,size_t` pairs  the goal is to reduce parameter counts and tie related params together 

This currently is to the internal files but I plan to make it part of the public interface if you like the idea.