### PR TITLE
expand test cases to cover both debug and release builds

### DIFF
--- a/.github/workflows/auto-test.yml
+++ b/.github/workflows/auto-test.yml
@@ -46,13 +46,16 @@ jobs:
 
   Linux_arm64_Clang_AS_USE_NAMESPACE:
     runs-on: ubuntu-24.04-arm
+    strategy:
+      matrix:
+        build_type: [Debug, Release]
     steps:
     - uses: actions/checkout@v4
     - name: build angelscript & test_feature
       run: |
         cd $GITHUB_WORKSPACE/sdk/tests/test_feature/projects/cmake
         cmake . -DCMAKE_CXX_FLAGS='-DAS_USE_NAMESPACE' -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
-        cmake --build .
+        cmake --build . --config ${{ matrix.build_type }}
     - name: run test_feature
       run: |
         cd $GITHUB_WORKSPACE/sdk/tests/test_feature/bin
@@ -60,6 +63,9 @@ jobs:
         
   Windows_x86-64_Clang:      
     runs-on: windows-latest
+    strategy:
+      matrix:
+        build_type: [Debug, Release]
     steps:
     - uses: actions/checkout@v4
     - name: set up Clang
@@ -73,15 +79,18 @@ jobs:
       run: |
         cd $env:GITHUB_WORKSPACE/sdk/tests/test_feature/projects/cmake
         cmake . -G Ninja -DCMAKE_C_COMPILER=clang -DCMAKE_CXX_COMPILER=clang++
-        cmake --build . --config Release
+        cmake --build . --config ${{ matrix.build_type }}
     - name: run test_feature
       shell: powershell
       run: |
         cd $env:GITHUB_WORKSPACE/sdk/tests/test_feature/bin
         ./test_feature.exe
 
-  Windows_x86-64_Clang-Cl:      
+  Windows_x86-64_Clang-Cl:
     runs-on: windows-latest
+    strategy:
+      matrix:
+        build_type: [Debug, Release]
     steps:
     - uses: actions/checkout@v4
     - name: set up Clang
@@ -89,8 +98,8 @@ jobs:
     - name: build angelscript & test_feature
       run: |
         cd ${{github.workspace}}/sdk/tests/test_feature/projects/cmake
-        cmake . -G Ninja -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl -DCMAKE_BUILD_TYPE=Release
-        cmake --build . --config Release
+        cmake . -G Ninja -DCMAKE_C_COMPILER=clang-cl -DCMAKE_CXX_COMPILER=clang-cl
+        cmake --build . --config ${{ matrix.build_type }}
     - name: run test_feature
       run: |
         cd ${{github.workspace}}/sdk/tests/test_feature/bin
@@ -98,13 +107,16 @@ jobs:
 
   MacOS_arm64_Clang:
     runs-on: macos-latest
+    strategy:
+      matrix:
+        build_type: [Debug, Release]
     steps:
     - uses: actions/checkout@v4
     - name: build angelscript & test_feature
       run: |
         cd $GITHUB_WORKSPACE/sdk/tests/test_feature/projects/cmake
         cmake .
-        cmake --build .
+        cmake --build . --config ${{ matrix.build_type }}
     - name: run test_feature
       run: |
         cd $GITHUB_WORKSPACE/sdk/tests/test_feature/bin
@@ -112,18 +124,19 @@ jobs:
 
   MacOS_x86-64_Clang:
     runs-on: macos-15-intel
+    strategy:
+      matrix:
+        build_type: [Debug, Release]
     steps:
     - uses: actions/checkout@v4
     - name: build angelscript & test_feature
       run: |
         cd $GITHUB_WORKSPACE/sdk/tests/test_feature/projects/cmake
         cmake .
-        cmake --build .
+        cmake --build . --config ${{ matrix.build_type }}
     - name: run test_feature
       run: |
         cd $GITHUB_WORKSPACE/sdk/tests/test_feature/bin
-        ./test_feature        
-        
-
+        ./test_feature
 
         


### PR DESCRIPTION
I'm running into this issue for newer releases of clang on osx x86. realized this is not observed because all my builds are debug locally I managed to reproduce this on my x86 mac machine after building this for release. you should probably cover both cases you have some differences between debug and release builds.

this is the working project i have where im running into this situation: 
https://github.com/TeamForbiddenLLC/warfork-qfusion/pull/503
```
/Users/**/third-party/angelscript/sdk/angelscript/source/as_callfunc_x64_gcc.cpp:148:4: error: 
      invalid CFI advance_loc expression
  148 |                 " .cfi_def_cfa_register rsp \n"
      |                  ^
<inline asm>:44:2: note: instantiated into assembly here
   44 |  .cfi_def_cfa_register rsp 
      |  ^
```

https://www.gamedev.net/forums/topic/717863-build-failure-on-x86-macos/5468407/
https://github.com/anjo76/angelscript/issues/30
