### PR TITLE
bugfix: resolve issue with CFI for osx x86_64

### DIFF
--- a/sdk/angelscript/source/as_callfunc_x64_gcc.cpp
+++ b/sdk/angelscript/source/as_callfunc_x64_gcc.cpp
@@ -106,17 +106,17 @@ static asQWORD __attribute__((noinline))
 	// Push the stack parameters, i.e. the arguments that won't be loaded into registers
 		"  movq %%rcx, %%rsi \n"
 		"  testl %%esi, %%esi \n"
-		"  jle endstack \n"
+		"  jle Lendstack \n"
 		"  subl $1, %%esi \n"
 		"  xorl %%edx, %%edx \n"
 		"  leaq 8(, %%rsi, 8), %%rcx \n"
-		"loopstack: \n"
+		"Lloopstack: \n"
 		"  movq 112(%%r10, %%rdx), %%rax \n"
 		"  pushq %%rax \n"
 		"  addq $8, %%rdx \n"
 		"  cmpq %%rcx, %%rdx \n"
-		"  jne loopstack \n"
-		"endstack: \n"
+		"  jne Lloopstack \n"
+		"Lendstack: \n"
 
 	// Populate integer and floating point parameters
 		"  movq %%r10, %%rax \n"


### PR DESCRIPTION
I found the relevant issue that explains the behavior. you can't have public labels between cfi directives. I switched these to private labels and verified that the code compiles correctly. Not sure if this is the valid fix though. 

```
Note: evaluateKnownAbsolute is to force folding A-B to a constant even if A and
B are separate by a non-private label. The function is a workaround for some
Mach-O assembler issues and should generally be avoided.
```

ref: https://github.com/llvm/llvm-project/commit/0b0672773e8b2ed01ad3fce103f4d84becfdd1ed