### PR TITLE
Fix warning from conversion

### DIFF
--- a/sdk/add_on/scriptbuilder/scriptbuilder.h
+++ b/sdk/add_on/scriptbuilder/scriptbuilder.h
@@ -201,9 +201,9 @@ protected:
 
 	struct ci_less
 	{
-		static int tolower_impl(unsigned char c)
+		static char tolower_impl(unsigned char c)
 		{
-			return std::tolower(c);
+			return static_cast<char>(std::tolower(c));
 		}
 		static std::string str_tolower(std::string s)
 		{


### PR DESCRIPTION
When I am building the library I get a possible truncation warning from int to char, this silences it