### PR TITLE
Fix missing else-if in SetConstantData/GetConstantData for big-endian.

### DIFF
--- a/sdk/angelscript/source/as_compiler.cpp
+++ b/sdk/angelscript/source/as_compiler.cpp
@@ -18320,9 +18320,9 @@ void asCExprValue::SetConstantData(const asCDataType &dt, asQWORD qw)
 	// works on both big endian and little endian CPUs.
 	if (dataType.GetSizeInMemoryBytes() == 1)
 		byteValue = (asBYTE)qw;
-	if (dataType.GetSizeInMemoryBytes() == 2)
+	else if (dataType.GetSizeInMemoryBytes() == 2)
 		wordValue = (asWORD)qw;
-	if (dataType.GetSizeInMemoryBytes() == 4)
+	else if (dataType.GetSizeInMemoryBytes() == 4)
 		dwordValue = (asDWORD)qw;
 	else
 		qwordValue = qw;
@@ -18335,9 +18335,9 @@ asQWORD asCExprValue::GetConstantData()
 	// works on both big endian and little endian CPUs.
 	if (dataType.GetSizeInMemoryBytes() == 1)
 		qw = byteValue;
-	if (dataType.GetSizeInMemoryBytes() == 2)
+	else if (dataType.GetSizeInMemoryBytes() == 2)
 		qw = wordValue;
-	if (dataType.GetSizeInMemoryBytes() == 4)
+	else if (dataType.GetSizeInMemoryBytes() == 4)
 		qw = dwordValue;
 	else
 		qw = qwordValue;


### PR DESCRIPTION
Hey, I noticed what looks like a little control-flow bug in `asCExprValue::SetConstantData()` and `asCExprValue::GetConstantData()` in as_compiler.cpp.

Both functions currently use a chain of independent `if` statements instead of `else if`. Because of this, when the size is 1 or 2, the code correctly writes byteValue/wordValue first, but then also falls through to the final `else` and overwrites the union with qwordValue. Since the union members share the same memory, on little-endian machines the overwrite happens to be harmless (the low bytes stay in place), but on big-endian machines the small value gets clobbered.

## The fix

Just changing those `if`s to `else if` so only one branch runs:

```cpp
if (dataType.GetSizeInMemoryBytes() == 1)
    byteValue = (asBYTE)qw;
else if (dataType.GetSizeInMemoryBytes() == 2)
    wordValue = (asWORD)qw;
else if (dataType.GetSizeInMemoryBytes() == 4)
    dwordValue = (asDWORD)qw;
else
    qwordValue = qw;
```

Same change in both `SetConstantData()` and `GetConstantData()`.

## How to reproduce

Here's a minimal AngelScript snippet that triggers the issue:

```angelscript
enum Small8 : int8
{
    Value8 = 42
}

enum Small16 : int16
{
    Value16 = 0x1234
}

int test_enum_int8()
{
    return Value8;
}

int test_enum_int16()
{
    return Value16;
}
```

And the cpp side code snippet to run it:

```cpp
// standard engine/module setup, not important...
int b = ExecuteFunction(engine, mod, "int test_enum_int8()");
int w = ExecuteFunction(engine, mod, "int test_enum_int16()");
std::cout << "test_enum_int8() -> " << b << "\n";
std::cout << "test_enum_int16() -> " << w << "\n";
```

I cross-compiled this with Zig targeting `s390x-linux-musl` (big-endian) and ran it under QEMU. Without the fix, both functions return `0`:


<img width="630" height="268" alt="Pasted image 20260407123044" src="https://github.com/user-attachments/assets/944d3fc0-e6f2-4456-80ca-ea55f933fe3b" />


With the fix applied, they return the expected `42` and `4660` (`0x1234`):


<img width="637" height="282" alt="Pasted image 20260407123658" src="https://github.com/user-attachments/assets/1f9e909f-886a-45d0-a847-3a6873c2e66e" />


Hope this helps!
