### PR TITLE
Fix thiscall with composite offset on system build with AS_NO_THISCALL_FUNCTOR_METHOD

### DIFF
--- a/sdk/angelscript/source/as_callfunc.cpp
+++ b/sdk/angelscript/source/as_callfunc.cpp
@@ -675,17 +675,23 @@ int CallSystemFunction(int id, asCContext *context)
 			// Skip the object pointer
 			args += AS_PTR_SIZE;
 		}
-		
-		// Add the base offset for multiple inheritance
+		if( obj )
+		{
+			// For composition we need to add the offset and/or dereference the pointer
+			obj = (void*)((char*)obj + sysFunc->compositeOffset);
+			if (sysFunc->isCompositeIndirect) obj = *((void**)obj);
+
+			// Add the base offset for multiple inheritance
 #if (defined(__GNUC__) && (defined(AS_ARM64) || defined(AS_ARM) || defined(AS_MIPS))) || defined(AS_PSVITA)
-		// On GNUC + ARM the lsb of the offset is used to indicate a virtual function
-		// and the whole offset is thus shifted one bit left to keep the original
-		// offset resolution
-		// MIPS also work like ARM in this regard
-		obj = (void*)(asPWORD(obj) + (sysFunc->baseOffset>>1));
+			// On GNUC + ARM the lsb of the offset is used to indicate a virtual function
+			// and the whole offset is thus shifted one bit left to keep the original
+			// offset resolution
+			// MIPS also work like ARM in this regard
+			obj = (void*)(asPWORD(obj) + (sysFunc->baseOffset>>1));
 #else
-		obj = (void*)(asPWORD(obj) + sysFunc->baseOffset);
+			obj = (void*)(asPWORD(obj) + sysFunc->baseOffset);
 #endif		
+		}
 	}
 #else // !defined(AS_NO_THISCALL_FUNCTOR_METHOD)
 


### PR DESCRIPTION
Issue discovered on OpenBSD playing [beyond-all-reason](https://github.com/beyond-all-reason).
The engine AI use an embeded angelscript which got updated recently.

The update include this commit https://github.com/anjo76/angelscript/commit/5090ec3f8b5c41e9a1ded3853f8854f5a9ad36c8

Before the change obj was adjusted with compositeOffset, just  before CallSystemFunctionNative.
```
	// For composition we need to add the offset and/or dereference the pointer
	if(obj)
	{
		obj = (void*) ((char*) obj + sysFunc->compositeOffset);
		if(sysFunc->isCompositeIndirect) obj = *((void**)obj);
	}
```

After the change it's only adjusted within #else // !defined(AS_NO_THISCALL_FUNCTOR_METHOD).

System configured with AS_NO_THISCALL_FUNCTOR_METHOD now breaks when using compositeOffset.

For exemple on OpenBSD.

> Program terminated with signal SIGSEGV, Segmentation fault.                                                                                                                                   
> #0  CScriptDictionary::Init (this=0x77cd3230f0, e=0x0)                                                                                                                                        
>     at /mnt/ext/_ports/pobj/recoil-rts-2025.06.24/RecoilEngine-2025.06.24/AI/Skirmish/BARb/src/lib/angelscript/add_on/scriptdictionary/scriptdictionary.cpp:89                                
> 89              SDictionaryCache *cache = reinterpret_cast<SDictionaryCache*>(engine->GetUserData(DICTIONARY_CACHE));           
> [Current thread is 1 (process 103736)]                                                                                                                                                        
> (gdb) bt                                                                                                                                                                                      
> #0  CScriptDictionary::Init (this=0x77cd3230f0, e=0x0)                                                                                                                                        
>     at /mnt/ext/_ports/pobj/recoil-rts-2025.06.24/RecoilEngine-2025.06.24/AI/Skirmish/BARb/src/lib/angelscript/add_on/scriptdictionary/scriptdictionary.cpp:89                                
> #1  CScriptDictionary::CScriptDictionary (this=0x77cd3230f0, engine=0x0)                                                                                                                      
>     at /mnt/ext/_ports/pobj/recoil-rts-2025.06.24/RecoilEngine-2025.06.24/AI/Skirmish/BARb/src/lib/angelscript/add_on/scriptdictionary/scriptdictionary.cpp:73                                
> #2  CScriptDictionary::Create (engine=0x0)                                                                                                                                                    
>     at /mnt/ext/_ports/pobj/recoil-rts-2025.06.24/RecoilEngine-2025.06.24/AI/Skirmish/BARb/src/lib/angelscript/add_on/scriptdictionary/scriptdictionary.cpp:59                                
> #3  0x000000794b6f586b in circuit::CSetupScript::GetModOptions (this=0x783c5dadd8)                                                                                                            
>     at /mnt/ext/_ports/pobj/recoil-rts-2025.06.24/RecoilEngine-2025.06.24/AI/Skirmish/BARb/src/circuit/script/SetupScript.cpp:33                                                              
> #4  0x000000794ba120f8 in X64_CallFunction (args=0x5, cnt=581339494, func=0x7822b44300 <_initial_thread>, retQW2=@0x7774e4c820: 0, returnFloat=false)
>     at /mnt/ext/_ports/pobj/recoil-rts-2025.06.24/RecoilEngine-2025.06.24/AI/Skirmish/BARb/src/lib/angelscript/source/as_callfunc_x64_gcc.cpp:79
> #5  0x0000000000000006 in ?? ()
> #6  0xf27c9b1d68a08fcf in ?? ()
> #7  0x0000709eb1297430 in ?? ()
> #8  0x000000794ba12002 in CallSystemFunctionNative (context=<optimized out>, descr=<error reading variable: Cannot access memory at address 0xffffffffffffff50>, 
>     obj=<error reading variable: Cannot access memory at address 0xffffffffffffff48>, args=<optimized out>, retPointer=<optimized out>, 
>     retQW2=<error reading variable: Cannot access memory at address 0xffffffffffffff38>, secondObject=<error reading variable: Cannot access memory at address 0x10>)
>     at /mnt/ext/_ports/pobj/recoil-rts-2025.06.24/RecoilEngine-2025.06.24/AI/Skirmish/BARb/src/lib/angelscript/source/as_callfunc_x64_gcc.cpp:473
> Backtrace stopped: previous frame inner to this frame (corrupt stack?)

We are missing the end of stack but this actually came from a ObjectMethod using composite members.
```
	CSetupManager* setupMgr = circuit->GetSetupManager();
	r = engine->RegisterObjectType("CSetupManager", 0, asOBJ_REF | asOBJ_NOHANDLE); ASSERT(r >= 0);
	r = engine->RegisterGlobalProperty("CSetupManager aiSetupMgr", setupMgr); ASSERT(r >= 0);
	// AS docs / "Registering object methods" / "Composite members"
	r = engine->RegisterObjectMethod("CSetupManager", "dictionary@ GetModOptions()", asMETHOD(CSetupScript, GetModOptions), asCALL_THISCALL, 0, asOFFSET(CSetupManager, script), true); ASSERT(r >= 0);
```

Without the offset adjustment we are using CSetupManager instead of CSetupManager->script and the function segfault.
