### PR TITLE
Allow asGetTypeTraits to be called in constexpr contexts

### DIFF
--- a/sdk/angelscript/include/angelscript.h
+++ b/sdk/angelscript/include/angelscript.h
@@ -603,7 +603,7 @@ END_AS_NAMESPACE
 #include <type_traits>
 BEGIN_AS_NAMESPACE
 
-template<typename T>
+template<typename T> constexpr
 asUINT asGetTypeTraits()
 {
 #if defined(_MSC_VER) || defined(_LIBCPP_TYPE_TRAITS) || (__GNUC__ >= 5) || (defined(__clang__) && !defined(CLANG_PRE_STANDARD))


### PR DESCRIPTION
I've decided to move on to supporting value types in my [reflective wrapper library](https://gamedev.net/forums/topic/720017-c26-reflection-follow-up/5474937/) early. As part of this, I'm working on the logic that determines which flags to apply to a given value type at compile time (which you were particularly keen on seeing implemented :eyes:).

Ideally, my implementation would first call `asGetTypeTraits<T>()`, and then compute the flags that said function cannot detect. The problem is that I only just found out that `asGetTypeTraits()` cannot be called at compile time. I took a quick look at its implementation and I couldn't find a reason why it shouldn't be callable at compile time, so I'm proposing that we make this function `constexpr`. It won't impact the way it's used today (as a `constexpr` function only specifies that it _may_ be called at compile time), but it _will_ allow me and others to call it within `consteval` functions, etc., should they wish to.

And seeing as `constexpr` was introduced in C++11, it should be perfectly fine to include it in a function that is excluded if the developer is working with an older version of the standard. But in fairness I haven't tried compiling this with anything other than the very new 16.1.0 version of GCC on Ubuntu that I'm working with.