### PR TITLE
Fix build with AS_NO_COMPILER

### DIFF
--- a/sdk/angelscript/source/as_builder.cpp
+++ b/sdk/angelscript/source/as_builder.cpp
@@ -87,7 +87,9 @@ asCBuilder::asCBuilder(asCScriptEngine *_engine, asCModule *_module)
 	silent = false;
 	numWarnings = 0;
 	numErrors = 0;
+#ifndef AS_NO_COMPILER
 	hasCachedKnownTypes = false;
+#endif
 }
 
 asCBuilder::~asCBuilder()


### PR DESCRIPTION
Since the introduction of the known-types cache, building with `AS_NO_COMPILER` defined fails:

```
as_builder.cpp(90): error C2065: 'hasCachedKnownTypes': undeclared identifier
```

`hasCachedKnownTypes` is declared inside the `#ifndef AS_NO_COMPILER` block in as_builder.h, but the `asCBuilder` constructor initializes it unconditionally. This guards the initialization the same way as the one in `asCBuilder::Reset()`.

Verified that the library builds cleanly with `AS_NO_COMPILER` on MSVC 19.44 after this change, and that bytecode loaded into the resulting runtime executes correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)