### PR TITLE
Fixed bytecode optimizer overwriting adjacent variable when fusing 64…

### DIFF
--- a/sdk/angelscript/source/as_bytecode.cpp
+++ b/sdk/angelscript/source/as_bytecode.cpp
@@ -406,6 +406,19 @@ bool asCByteCode::PostponeInitOfTemp(asCByteInstruction *curr, asCByteInstructio
 	return false;
 }
 
+// Returns true if the instruction writes a 64bit value to its destination variable
+static bool IsInstrWith64bitResult(asEBCInstr op)
+{
+	return op == asBC_ADDi64 || op == asBC_SUBi64 || op == asBC_MULi64 ||
+	       op == asBC_DIVi64 || op == asBC_MODi64 || op == asBC_DIVu64 ||
+	       op == asBC_MODu64 || op == asBC_BAND64 || op == asBC_BOR64  ||
+	       op == asBC_BXOR64 || op == asBC_BSLL64 || op == asBC_BSRL64 ||
+	       op == asBC_BSRA64 || op == asBC_ADDd   || op == asBC_SUBd   ||
+	       op == asBC_MULd   || op == asBC_DIVd   || op == asBC_MODd   ||
+	       op == asBC_POWd   || op == asBC_POWdi  || op == asBC_POWi64 ||
+	       op == asBC_POWu64;
+}
+
 bool asCByteCode::RemoveUnusedValue(asCByteInstruction *curr, asCByteInstruction **next)
 {
 	TimeIt("asCByteCode::RemoveUnusedValue");
@@ -548,8 +561,11 @@ bool asCByteCode::RemoveUnusedValue(asCByteInstruction *curr, asCByteInstruction
 	}
 
 	// The value is immediately moved to another variable and then not used again
+	// This must not be done for instructions with a 64bit result, since retargeting
+	// them to the 4byte destination of the CpyVtoV4 would overwrite the adjacent variable
 	if( (asBCInfo[curr->op].type == asBCTYPE_wW_rW_rW_ARG ||
 		 asBCInfo[curr->op].type == asBCTYPE_wW_rW_DW_ARG) &&
+		!IsInstrWith64bitResult(curr->op) &&
 		curr->next && curr->next->op == asBC_CpyVtoV4 &&
 		curr->wArg[0] == curr->next->wArg[1] &&
 		IsTemporary(curr->wArg[0]) &&

--- a/sdk/tests/test_feature/source/test_optimize.cpp
+++ b/sdk/tests/test_feature/source/test_optimize.cpp
@@ -408,6 +408,40 @@ bool TestOptimize()
 {
 	bool fail = false;
 
+	// Test that the optimization doesn't retarget an instruction with a 64bit result
+	// to the 4byte destination of a following CpyVtoV4, as the 8byte write would
+	// overwrite the variable adjacent to the destination
+	{
+		asIScriptEngine *engine = asCreateScriptEngine();
+		COutStream out;
+		engine->SetMessageCallback(asMETHOD(COutStream, Callback), &out, asCALL_THISCALL);
+
+		asIScriptModule *mod = engine->GetModule("mod", asGM_ALWAYS_CREATE);
+		mod->AddScriptSection("test",
+			"enum E { A, B, C, D } \n"
+			"int func() { \n"
+			"	uint64 big = 3; \n"
+			"	uint64 canary = 42; \n"
+			"	E t = E(big & 3); \n"  // BAND64 into a 64bit temp, then CpyVtoV4 to t
+			"	return int(canary) * 1000 + int(t); \n"
+			"} \n");
+		int r = mod->Build();
+		if (r < 0)
+			TEST_FAILED;
+
+		asIScriptFunction *func = mod->GetFunctionByName("func");
+		asIScriptContext *ctx = engine->CreateContext();
+		ctx->Prepare(func);
+		r = ctx->Execute();
+		if (r != asEXECUTION_FINISHED)
+			TEST_FAILED;
+		if (ctx->GetReturnDWord() != 42003)
+			TEST_FAILED;
+		ctx->Release();
+
+		engine->ShutDownAndRelease();
+	}
+
 	// Test optimized operations
 	{
 		asIScriptEngine* engine = asCreateScriptEngine();


### PR DESCRIPTION
…bit instruction with CpyVtoV4

The RemoveUnusedValue optimization retargeted any wW_rW_rW/wW_rW_DW instruction to the destination of a following CpyVtoV4 when the temporary was not read again. For instructions with a 64bit result (e.g. BAND64, produced by 'enumVar = Enum(u64expr & mask)', where the conversion relies on CpyVtoV4 to truncate) the fused instruction writes 8 bytes into the 4byte destination, corrupting the variable on the adjacent stack slot -- e.g. zeroing the low dword of an object handle, which then crashes on the next method call on that handle.